### PR TITLE
feat: add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,12 +21,17 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [12.*]
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: [13.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,18 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^12.18",
-        "illuminate/database": "^12.18"
+        "illuminate/contracts": "^12.18|^13.0",
+        "illuminate/database": "^12.18|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.24",
         "nunomaduro/collision": "^8.8",
         "larastan/larastan": "^3.6",
-        "orchestra/testbench": "^10.4",
-        "pestphp/pest": "^3.8",
-        "pestphp/pest-plugin-arch": "^3.1",
-        "pestphp/pest-plugin-laravel": "^3.2",
+        "orchestra/testbench": "^10.8|^11.0",
+        "pestphp/pest": "^3.8|^4.1",
+        "pestphp/pest-plugin-arch": "^3.1|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.1|^4.0",
+        "pestphp/pest-plugin-type-coverage": "^3.4|^4.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0"


### PR DESCRIPTION
## What changed

- Extended `illuminate/contracts` and `illuminate/database` constraints to include `^13.0`
- Widened dev dependencies (`orchestra/testbench`, `pestphp/pest` and its plugins) to support Laravel 13 / Pest 4 equivalents
- Added `pestphp/pest-plugin-type-coverage` to dev dependencies
- Added PHP `8.5` and Laravel `13.*` (with `testbench: 11.*`) to the CI test matrix

## Why

Laravel 13 and PHP 8.5 have been released. This PR ensures the package is compatible with both while retaining support for Laravel 12 and PHP 8.2–8.4.

## Reviewer notes

The existing source code required no changes — only dependency constraints and the CI matrix needed updating.